### PR TITLE
refactor: change target repository

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ function main() {
       branch: string
       filterPath?: (p: string) => boolean
     } = {
-      target: 'nuxt/docs',
+      target: 'nuxt/nuxtjs.org',
       branch: 'master'
     }
     const startsWith = Config.upstream.startsWith


### PR DESCRIPTION
Nuxt.js の ドキュメントが置かれているレポジトリが nuxt/docs から nuxt/nuxtjs.org/content に変更されたので、その修正です。

Rel: #23 