### PR TITLE
issueに更新されたファイル名を記載、ラベルをつけるよう修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,9 @@ async function receiveNewCommit(commit: Commit) {
     repo: Config.origin.repo,
     title: `[doc] ${title.replace(/( )?\(#.*\)/, '')}`,
     labels: ['help wanted'],
-    body: `本家のドキュメントに更新がありました :page_facing_up:\r\nOriginal:${
+    body: `本家のドキュメントに更新がありました :page_facing_up:\r\nOriginal: ${
       commit.link
-    }`
+    }\r\nFiles:\r\n ${commit.filenames.join('\r\n')}`
   }
   try {
     const {

--- a/src/lib/GitHubBranchWatcher.ts
+++ b/src/lib/GitHubBranchWatcher.ts
@@ -7,6 +7,7 @@ export type Commit = {
   link: string
   message: string
   commit: string
+  filenames: Array<string>
 }
 
 type Target = {
@@ -84,6 +85,7 @@ export default class extends EventEmitter {
   private async runner() {
     const main = async (target: Target) => {
       const seenCommit = this.seenCommits.get(target.seenCommitKey) || {}
+      let filenames: string[]
 
       const { repo, owner, filterPath } = target
 
@@ -114,10 +116,14 @@ export default class extends EventEmitter {
             owner,
             sha
           })
-          const f = files.filter(({ filename }) => {
-            return filterPath(filename)
-          })
-          if (f.length === 0) {
+          filenames = files
+            .filter(({ filename }) => {
+              return filterPath(filename)
+            })
+            .map(({ filename }) => {
+              return filename
+            })
+          if (filenames.length === 0) {
             // ignored
             seenCommit[sha] = true
             return
@@ -130,7 +136,8 @@ export default class extends EventEmitter {
             owner,
             commit: d.sha,
             link: html_url,
-            message
+            message,
+            filenames
           })
         ) {
           seenCommit[sha] = true


### PR DESCRIPTION
## 背景

手動でコミットを見に行ってどのファイルが更新されたか確認、ラベルを貼るオペレーションを楽にしたい
（例えば `blog` が更新されていたら `blog` ラベルをつけるなど）

## 修正内容

- 329185b 起票する issue に更新されたファイル名を記載するよう修正
- 82100c8 更新対象のドキュメントのラベルをつけるよう修正
  - `blog` 以外もついでにつけるようにしました