### PR TITLE
chore(deps): update typescript 3.3.1 to 3.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/consola": "^1.0.0",
     "@types/node": "^11.13.6",
     "standard-version": "^8.0.1",
-    "typescript": "^3.3.1"
+    "typescript": "^3.4.5"
   },
   "dependencies": {
     "@octokit/rest": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,10 +1744,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
-  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
+typescript@^3.4.5:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
## 背景

#25 で [`const assertions`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) を使いたので TypeScript のバージョンを 3.4 系にあげたい

## 修正内容

TypeScript のバージョンを `3.3.1` から `3.4.5` に変更

## Ref

ざっと関連ドキュメントを見たところ影響はなさそうでした。また、ローカルで動作確認したところ問題ありませんでした。

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html
- https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/
- https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-34
- https://github.com/microsoft/TypeScript/releases/tag/v3.4.2
- https://github.com/microsoft/TypeScript/releases/tag/v3.4.3
- https://github.com/microsoft/TypeScript/releases/tag/v3.4.4