### PR TITLE
Nuxt v3 ドキュメントの変更が落ち着くまで停止する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn lint:prettier
-      - run: yarn start
+      - run: echo "Pending until Nuxt v3 documents upgrade is settled"
+      # - run: yarn start
 
 workflows:
   version: 2


### PR DESCRIPTION
Nuxt v3 のドキュメントが公開されるまで https://github.com/nuxt/nuxtjs.org に対してディレクトリの変更を含む大幅な変更が加えられています。

コンフリクトを回避するために Nuxt v3 ドキュメントの更新が落ち着くまで、sharin を停止します。